### PR TITLE
[FIX] session token cookie management

### DIFF
--- a/website_event_private/controllers/main.py
+++ b/website_event_private/controllers/main.py
@@ -36,27 +36,31 @@ class WebsiteEvent(WebsiteEventController):
     # Business method
     # ------------------------------------------------------
     def _check_privacy(self, event, **post):
+        # for private events, check authorization
         if event.event_privacy != "public" and not request.env.user.has_group(
             "website.group_website_restricted_editor"
         ):
+            # get cookie from http request
             cookie = request.httprequest.cookies.get("odoo-event-%d" % event.id)
-            if (
-                post
-                and post.get("access_token")
-                and post.get("access_token") == event.access_token
-            ):
+            # check if cookie match access token
+            if cookie and cookie == event.access_token:
+                return True
+            # if cookie does not match, get the cookie from url
+            if post and post.get("access_token"):
                 access_token = post.get("access_token")
-                request.future_response.set_cookie(
-                    key="odoo-event-%d" % event.id,
-                    value=access_token,
-                    max_age=10 * 86400,
-                    secure=True,
-                    httponly=True,
-                    samesite="Strict",
-                )
-                return True
-            elif cookie and cookie == event.access_token:
-                return True
-            else:
-                return False
+                # if the cookie is correct, set the cookie accordingly and succeed
+                if access_token == event.access_token:
+                    request.future_response.set_cookie(
+                        key="odoo-event-%d" % event.id,
+                        value=access_token,
+                        max_age=10 * 86400,
+                        secure=True,
+                        httponly=True,
+                        samesite="Strict",
+                    )
+                    return True
+                # if cookie is incorrect, do not set the cookie and fail
+                else:
+                    return False
+        # for public event or if user is authorized, allow access
         return True


### PR DESCRIPTION
Code was checking URL first before cookies which lead to incorrect authorization detection in some cases.

Example:
- clicking link from thunderbird was ok
- clicking link from browser was ko
- copying link in browser url was ok

This fix gets all cases working as expected.